### PR TITLE
Bump update-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: meson compile osx-build-dmg -C build_static
 
       - name: Upload artifacts - macOS dmg
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Aegisub-3.2.2-darwin-aarch64
           path: build_static/Aegisub-3.2.2.dmg


### PR DESCRIPTION
Reasons for changes:
- Silence deprecation warnings
- Should be [much faster](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions)

Testing: 
- Ensure CI passes
- Check whether deprecation warning is gone